### PR TITLE
ブログのアイキャッチ画像 `height`修正

### DIFF
--- a/pages/blog/[id].tsx
+++ b/pages/blog/[id].tsx
@@ -188,7 +188,7 @@ const BlogEntryPage: NextPage<
                 height={
                   entry.featuredImage.height > FEATURED_IMAGE_MAX_HEIGHT
                     ? FEATURED_IMAGE_MAX_HEIGHT
-                    : entry.featuredImage.url
+                    : entry.featuredImage.height
                 }
                 priority
               />


### PR DESCRIPTION
なぜか `url` を指定していた