### PR TITLE
Modify Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,70 +1,58 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ],
+  "extends": ["config:base"],
   "timezone": "Asia/Tokyo",
+  "schedule": ["before 3am on Monday"],
   "prHourlyLimit": 0,
   "rangeStrategy": "bump",
-  "labels": [
-    "dependencies"
-  ],
-  "ignoreDeps": [
-    "npm"
-  ],
+  "labels": ["dependencies"],
+  "ignoreDeps": ["npm"],
   "packageRules": [
     {
-      "groupName": "Next.js",
-      "matchPackageNames": [
-        "next",
-        "eslint-config-next"
-      ],
-      "matchPackagePatterns": [
-        "^@next/"
-      ],
+      "matchDepTypes": ["dependencies"],
       "automerge": false
     },
     {
-      "groupName": "React",
-      "matchPackageNames": [
-        "react",
-        "react-dom"
-      ],
-      "automerge": false
+      "matchDepTypes": ["devDependencies"],
+      "automerge": true
     },
     {
-      "groupName": "Theme UI",
-      "matchPackageNames": [
-        "theme-ui"
-      ],
-      "matchPackagePatterns": [
-        "^@theme-ui/"
-      ],
-      "automerge": false
-    },
-    {
-      "groupName": "Linters",
-      "matchPackagePatterns": [
-        "eslint"
-      ],
-      "matchPackageNames": [
-        "prettier"
-      ],
-      "excludePackageNames": [
-        "eslint-config-next"
-      ]
-    },
-    {
-      "groupName": "metascraper",
-      "matchPackagePatterns": [
-        "^metascraper"
-      ]
+      "matchPackageNames": ["node"],
+      "schedule": ["before 3am on the first day of the month"],
+      "automerge": true
     },
     {
       "groupName": "@types",
-      "matchPackagePrefixes": [
-        "@types/"
-      ]
+      "matchPackagePrefixes": ["@types/"],
+      "automerge": true
+    },
+    {
+      "groupName": "linters",
+      "matchPackagePatterns": ["eslint"],
+      "matchPackageNames": ["prettier"],
+      "automerge": true
+    },
+    {
+      "groupName": "metascraper",
+      "matchPackagePatterns": ["^metascraper"],
+      "automerge": true
+    },
+    {
+      "groupName": "theme-ui",
+      "matchPackageNames": ["theme-ui"],
+      "matchPackagePatterns": ["^@theme-ui/"],
+      "automerge": false
+    },
+    {
+      "groupName": "next",
+      "matchPackageNames": ["next", "eslint-config-next"],
+      "matchPackagePatterns": ["^@next/"],
+      "automerge": false
+    },
+    {
+      "groupName": "react",
+      "matchPackageNames": ["react", "react-dom"],
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
- スケジュール設定
- packageRulesの優先順位整理
  https://docs.renovatebot.com/configuration-options/#packagerules
  > Important to know: Renovate will evaluate all packageRules and not stop once it gets a first match. You should order your packageRules in ascending order of importance so that more important rules come later and can override settings from earlier rules if needed.