### PR TITLE
fix: Renovate Node.js config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,11 @@
       "automerge": false
     },
     {
-      "matchDepTypes": ["devDependencies", "engines", "packageManager"],
+      "matchDepTypes": ["devDependencies", "packageManager"],
+      "automerge": true
+    },
+    {
+      "matchPackageNames": ["node"],
       "automerge": true
     },
     {
@@ -23,7 +27,7 @@
       "automerge": false
     },
     {
-      "matchDepTypes": ["engines"],
+      "matchPackageNames": ["node"],
       "extends": ["schedule:monthly"]
     }
   ],


### PR DESCRIPTION
- `.node-version`移行 https://github.com/kamatte-me/kamatte-syndrome/pull/417 に伴い変更
- Renovateの`.node-version`とpackage.jsonの `engines` の挙動差異があったため