### PR TITLE
Renovate Node.js minimumReleaseAge

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -32,6 +32,7 @@
     {
       matchPackageNames: ['node'],
       extends: ['schedule:monthly'],
+      minimumReleaseAge: '3 days',
     },
   ],
   vulnerabilityAlerts: {


### PR DESCRIPTION
- リリース直後は各SaaSで未対応なことが多いため、PRが出来てから3日待つ