### PR TITLE
fix: parseHTML iframely condition

### DIFF
--- a/lib/parseHTML.tsx
+++ b/lib/parseHTML.tsx
@@ -99,8 +99,8 @@ const parseOption: HTMLReactParserOptions = {
     }
 
     if (
-      attrProps.className &&
-      (attrProps.className as string).startsWith('iframely-')
+      typeof attrProps.className === 'string' &&
+      attrProps.className.startsWith('iframely-')
     ) {
       return domNode;
     }


### PR DESCRIPTION
`attrProps.className`が万が一booleanだった場合に死ぬリスクあった