### PR TITLE
Mod Renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -30,7 +30,5 @@
   },
   vulnerabilityAlerts: {
     enabled: true,
-    addLabels: ['security'],
-    automerge: true,
   },
 }


### PR DESCRIPTION
`vulnerabilityAlerts`から
- `security`ラベル設定削除
- 不要な`automerge`削除