### PR TITLE
ci: cache workspace tasks with Turborepo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,13 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - run: pnpm install
+      - name: Restore Turborepo cache
+        uses: actions/cache@v6.1.0
+        with:
+          path: .turbo
+          key: turborepo-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+          restore-keys: |
+            turborepo-v1-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
       - name: Restore image optimization cache
         uses: actions/cache@v6.1.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Dependencies
 node_modules/
 .pnpm-store/
+.turbo/
 
 # TypeScript output
 *.tsbuildinfo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 
 - `kamatte-syndrome` は TanStack Start / React 19 / Vite ベースのサイトです。
 - pnpm workspace 構成です。Vite アプリ本体は `apps/web/`、共有パッケージは `packages/` にあります。
+- `pnpm build`、`pnpm test`、`pnpm typecheck`はTurborepoで実行します。タスクの依存グラフとキャッシュ設定はリポジトリルートの`turbo.json`で管理します。
 - ルーティングは TanStack Router の file-based routing です。ルートは `apps/web/src/routes/` に置きます。
 - 記事などのコンテンツは `@content-collections/*` で収集され、設定は `apps/web/content-collections.ts` にあります。
 - スタイルは Tailwind CSS v4 を基本に、Tailwind だけでは表現しにくい場合に CSS Modules を使います。グローバル CSS は `apps/web/src/styles.css` です。
@@ -17,14 +18,21 @@
 - Node.js は `package.json` の `engines.node` に合わせて `24.x` を想定します。
 - よく使うコマンド:
   - `pnpm dev`: `apps/web` の開発サーバー
-  - `pnpm build`: `apps/web` の本番ビルド
+  - `pnpm build`: Turborepoで依存順に実行するworkspace全体の本番ビルド
   - `pnpm start`: `apps/web/.output` の Node サーバー起動
   - `pnpm lint`: Biome によるチェック
   - `pnpm lint:fix`: Biome の自動修正
-  - `pnpm typecheck`: workspace 各 package/app の TypeScript 型チェック
-  - `pnpm test`: workspace 各 package/app の Vitest
+  - `pnpm typecheck`: Turborepoで実行するworkspace各package/appのTypeScript型チェック
+  - `pnpm test`: Turborepoで実行するworkspace各package/appのVitest
 
 変更後は、影響範囲に応じて `pnpm lint`、`pnpm typecheck`、`pnpm test`、`pnpm build` のうち必要なものを実行してください。
+
+### Turborepo
+
+- タスク設定はルートの`turbo.json`で管理します。ビルド・テスト・型チェックは、キャッシュを利用できるルートスクリプト（`pnpm build`、`pnpm test`、`pnpm typecheck`）で実行してください。
+- 新しいタスクを追加したり、生成物を変えたりする場合は、対応する`outputs`を`turbo.json`に明示します。テストと型チェックのように出力を再利用しないタスクは`outputs: []`を維持します。
+- タスクがPrivateコンテンツ、環境変数、設定ファイルなどを読む場合は、キャッシュの正しさを保つため、対応する`inputs`、`env`、`globalDependencies`を更新してください。Webビルドではコンテンツと`VITE_*`環境変数を既に追跡しています。
+- `.turbo/`は生成されるローカルキャッシュです。コミットしないでください。
 
 ## コーディング規約
 
@@ -73,6 +81,7 @@
 - Vercel の Root Directory は `apps/web` です。[`apps/web/vercel.json`](apps/web/vercel.json) は `pnpm install --frozen-lockfile` の後、`pnpm sync:content && pnpm build` を実行します。
 - Vercel は非公開の `CONTENT_REPOSITORY_TOKEN` で `sync:content` を実行し、Private コンテンツリポジトリを shallow clone します。このトークンを `VITE_` 接頭辞の環境変数やクライアントコードに置かないでください。
 - CI は `sync:content` を使いません。GitHub App の短期トークンを発行し、`actions/checkout` で `apps/web/kamatte-syndrome-content` へコンテンツを checkout します。認証経路を Vercel と統一・置換しないでください。
+- CIは`pnpm install`の後、`.turbo/`全体をGitHub Actions Cacheから復元します。Turborepoのキャッシュ対象を`.turbo/cache`だけに狭めたり、キャッシュキーから`pnpm-lock.yaml`を外したりしないでください。
 - `sync:content` は既存のコンテンツディレクトリを置き換えないよう、ディレクトリが存在すると停止します。ローカルの symlink や checkout を削除して実行しないでください。
 
 ## Atomフィード通知

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ flowchart LR
 
 ## リポジトリ構成
 
+pnpm workspaceと[Turborepo](https://turborepo.dev/)を使用したモノレポ構成です。
+
 ```text
 .
 ├── .github/
@@ -60,7 +62,8 @@ flowchart LR
 │   ├── vite-plugin-optimized-social-image/
 │   └── vite-plugin-react-optimized-responsive-image/
 ├── pnpm-workspace.yaml
-└── package.json
+├── package.json
+└── turbo.json
 ```
 
 アプリ固有の構成、環境変数、デプロイ方法は [apps/web/README.md](apps/web/README.md) を参照してください。
@@ -103,6 +106,8 @@ pnpm install
 | `pnpm vercel:env:pull` | Vercelの環境変数を各workspaceに取得 |
 
 Webアプリだけを対象にする場合は、たとえば`pnpm --filter web test`のように`--filter web`を付けます。
+
+workspaceタスクの実行・キャッシュには[Turborepo](https://turborepo.dev/)を使用しています。設定はリポジトリルートの[`turbo.json`](turbo.json)で管理し、キャッシュは`.turbo/`に保存されます。
 
 ## 品質チェック
 

--- a/package.json
+++ b/package.json
@@ -7,18 +7,19 @@
   "type": "module",
   "scripts": {
     "dev": "pnpm --filter web dev",
-    "build": "pnpm -r build",
+    "build": "turbo run build",
     "start": "pnpm -r start",
     "lint": "biome check",
     "lint:fix": "biome check --write",
     "lint:ci": "biome ci",
-    "typecheck": "pnpm -r typecheck",
-    "test": "pnpm -r test",
+    "typecheck": "turbo run typecheck",
+    "test": "turbo run test",
     "vercel:env:pull": "pnpm -r vercel:env:pull"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.8",
-    "@tanstack/intent": "0.3.6"
+    "@tanstack/intent": "0.3.6",
+    "turbo": "2.10.10"
   },
   "engines": {
     "node": "24.x"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@tanstack/intent':
         specifier: 0.3.6
         version: 0.3.6
+      turbo:
+        specifier: 2.10.10
+        version: 2.10.10
 
   .github/actions/broadcast-to-line:
     devDependencies:
@@ -2048,6 +2051,36 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@turbo/darwin-64@2.10.10':
+    resolution: {integrity: sha512-gFDD+wRP5hWxBRghGyEbjpbLOY7aIU/wvsnKdMM7odQcp/wHMrnI83p0FyxxMRZnFH9ZD+S59MvcpOC5b+nrCA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@turbo/darwin-arm64@2.10.10':
+    resolution: {integrity: sha512-VZYsxZ6yjyDosUqtiroAVSXPLmx/qBxdHJgIxdMH9RyNmLdOLOWtJnYMnI4qckwCgQMK85G3fu94/xk5+iBCgw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@turbo/linux-64@2.10.10':
+    resolution: {integrity: sha512-lAvW+yEnmsCKMEIwNugjozawvYytHKPhU0kfLBizu83MIs8OUb9KobYvkZ56L5akSM6K7+gBFLEIfQkaceh90g==}
+    cpu: [x64]
+    os: [android, linux]
+
+  '@turbo/linux-arm64@2.10.10':
+    resolution: {integrity: sha512-MSJ+NkRTd79Z9+YEZpUV9VOWVOOigFhE+v/ETNYJEuTJp3r00y9YgFvDXrmM+DP8Kal6tk3U6xSugD2/Ojh+Jg==}
+    cpu: [arm64]
+    os: [android, linux]
+
+  '@turbo/windows-64@2.10.10':
+    resolution: {integrity: sha512-ycWpXDkUfnDFDY9d+4Qna/UZotDB0wj+s9agrlmNt0Q7a3XHORhK8GPKJdzgzeutXu9EW5P/jyabTEHlohuDXw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@turbo/windows-arm64@2.10.10':
+    resolution: {integrity: sha512-PMk6zQN0csUFklLe+1hz/5G9uU1YmV0cEIey2R/bSeA6o69qcBTlN4A3jOqkgenOO5dOpMHmq2sEUZo8r1+Ssg==}
+    cpu: [arm64]
+    os: [win32]
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
@@ -3776,6 +3809,10 @@ packages:
   turbo-stream@3.2.0:
     resolution: {integrity: sha512-EK+bZ9UVrVh7JLslVFOV0GEMsociOqVOvEMTAd4ixMyffN5YNIEdLZWXUx5PJqDbTxSIBWw04HS9gCY4frYQDQ==}
 
+  turbo@2.10.10:
+    resolution: {integrity: sha512-/90KTW+USzvYOPmafRZHVKLBsHXQ5810Ao/HdtJYAqguIhZ+XruS6eIUjqJUDtrSxaZYynNFht68qckGKAOWTA==}
+    hasBin: true
+
   type-fest@5.8.0:
     resolution: {integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==}
     engines: {node: '>=20'}
@@ -5431,6 +5468,24 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
       '@types/react-dom': 19.2.4(@types/react@19.2.18)
+
+  '@turbo/darwin-64@2.10.10':
+    optional: true
+
+  '@turbo/darwin-arm64@2.10.10':
+    optional: true
+
+  '@turbo/linux-64@2.10.10':
+    optional: true
+
+  '@turbo/linux-arm64@2.10.10':
+    optional: true
+
+  '@turbo/windows-64@2.10.10':
+    optional: true
+
+  '@turbo/windows-arm64@2.10.10':
+    optional: true
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -7395,6 +7450,15 @@ snapshots:
     optional: true
 
   turbo-stream@3.2.0: {}
+
+  turbo@2.10.10:
+    optionalDependencies:
+      '@turbo/darwin-64': 2.10.10
+      '@turbo/darwin-arm64': 2.10.10
+      '@turbo/linux-64': 2.10.10
+      '@turbo/linux-arm64': 2.10.10
+      '@turbo/windows-64': 2.10.10
+      '@turbo/windows-arm64': 2.10.10
 
   type-fest@5.8.0:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turborepo.com/schema.json",
+  "$schema": "./node_modules/turbo/schema.json",
   "globalDependencies": [".node-version"],
   "tasks": {
     "build": {

--- a/turbo.json
+++ b/turbo.json
@@ -11,6 +11,7 @@
       ],
       "inputs": [
         "$TURBO_DEFAULT$",
+        ".env*",
         "kamatte-syndrome-content/content/**",
         "kamatte-syndrome-content/media/**"
       ],

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "globalDependencies": [".node-version"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "env": [
+        "VITE_FACEBOOK_APP_ID",
+        "VITE_GOOGLE_ANALYTICS_ID",
+        "VITE_SHOW_UNPUBLISHED_CONTENT"
+      ],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "kamatte-syndrome-content/content/**",
+        "kamatte-syndrome-content/media/**"
+      ],
+      "outputs": [".output/**", "dist/**"]
+    },
+    "test": {
+      "dependsOn": ["^test"],
+      "env": [
+        "VITE_FACEBOOK_APP_ID",
+        "VITE_GOOGLE_ANALYTICS_ID",
+        "VITE_SHOW_UNPUBLISHED_CONTENT"
+      ],
+      "outputs": []
+    },
+    "typecheck": {
+      "dependsOn": ["^typecheck"],
+      "outputs": []
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Turborepo task orchestration for build, test, and typecheck
- cache the complete .turbo directory in GitHub Actions
- include site content, Vite environment variables, and local .env files in the build cache inputs
- document the monorepo and Turborepo workflow in README.md and AGENTS.md
- use the installed Turbo JSON schema for editor validation

## Validation
- pnpm lint
- pnpm typecheck
- pnpm exec turbo run build --output-logs=errors-only (second run: full cache hit)

## Notes
- The full test run was attempted, but an existing symlink-watcher test in vite-plugin-optimized-social-image timed out in this environment.