### PR TITLE
Fix empty Open Graph image fallback

### DIFF
--- a/apps/web/src/utils/pageMeta.test.ts
+++ b/apps/web/src/utils/pageMeta.test.ts
@@ -76,4 +76,19 @@ describe('createPageMeta', () => {
       content: 'https://kamatte.me/icon.png',
     });
   });
+
+  it('uses the site icon when the image is empty', () => {
+    const meta = createPageMeta({
+      title: 'Article title',
+      description: 'Article description',
+      image: '',
+      path: '/blog/example',
+      type: 'article',
+    });
+
+    expect(meta).toContainEqual({
+      property: 'og:image',
+      content: 'https://kamatte.me/icon.png',
+    });
+  });
 });

--- a/apps/web/src/utils/pageMeta.ts
+++ b/apps/web/src/utils/pageMeta.ts
@@ -35,7 +35,10 @@ export function createPageMeta({
   type = 'website',
 }: PageMetaOptions): PageMeta[] {
   const url = new URL(path, baseUrl).href;
-  const imageUrl = new URL(resolveContentMediaUrl(image), baseUrl).href;
+  const imageUrl = new URL(
+    resolveContentMediaUrl(image) || '/icon.png',
+    baseUrl,
+  ).href;
 
   return [
     { title },


### PR DESCRIPTION
## Summary
- fall back to the site icon when an Open Graph image is an empty string
- add a regression test for empty featured images

## Validation
- pnpm --filter web test --run src/utils/pageMeta.test.ts
- pnpm lint
- pnpm typecheck
- git diff --check