### PR TITLE
refactor(actions): rename X consumer credentials

### DIFF
--- a/.github/actions/post-to-x/README.md
+++ b/.github/actions/post-to-x/README.md
@@ -7,8 +7,8 @@ OAuth 1.0aでX APIの投稿エンドポイントへテキストを1件投稿す�
 | Input | Required | Description |
 | --- | --- | --- |
 | `text` | Yes | 投稿する本文 |
-| `api-key` | Yes | X API key |
-| `api-key-secret` | Yes | X API key secret |
+| `consumer-key` | Yes | X OAuth 1.0a consumer key |
+| `consumer-secret` | Yes | X OAuth 1.0a consumer secret |
 | `access-token` | Yes | 投稿アカウントのaccess token |
 | `access-token-secret` | Yes | 投稿アカウントのaccess token secret |
 
@@ -19,8 +19,8 @@ OAuth 1.0aでX APIの投稿エンドポイントへテキストを1件投稿す�
 ```yaml
 - uses: ./.github/actions/post-to-x
   with:
-    api-key: ${{ secrets.X_API_KEY }}
-    api-key-secret: ${{ secrets.X_API_KEY_SECRET }}
+    consumer-key: ${{ secrets.X_CONSUMER_KEY }}
+    consumer-secret: ${{ secrets.X_CONSUMER_SECRET }}
     access-token: ${{ secrets.X_ACCESS_TOKEN }}
     access-token-secret: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
     text: |

--- a/.github/actions/post-to-x/action.yml
+++ b/.github/actions/post-to-x/action.yml
@@ -4,11 +4,11 @@ inputs:
   text:
     description: Text to publish.
     required: true
-  api-key:
-    description: X API key.
+  consumer-key:
+    description: X OAuth 1.0a consumer key.
     required: true
-  api-key-secret:
-    description: X API key secret.
+  consumer-secret:
+    description: X OAuth 1.0a consumer secret.
     required: true
   access-token:
     description: X access token.

--- a/.github/actions/post-to-x/dist/index.js
+++ b/.github/actions/post-to-x/dist/index.js
@@ -37,7 +37,7 @@ async function publishTextToX(text, options) {
 }
 function createOAuthAuthorizationHeader(method, url, credentials) {
   const oauthParameters = {
-    oauth_consumer_key: credentials.apiKey,
+    oauth_consumer_key: credentials.consumerKey,
     oauth_nonce: randomBytes(16).toString("hex"),
     oauth_signature_method: "HMAC-SHA1",
     oauth_timestamp: String(Math.floor(Date.now() / 1e3)),
@@ -59,7 +59,7 @@ function createOAuthAuthorizationHeader(method, url, credentials) {
     oauthEncode(baseUrl),
     oauthEncode(parameterString)
   ].join("&");
-  const signingKey = `${oauthEncode(credentials.apiKeySecret)}&${oauthEncode(credentials.accessTokenSecret)}`;
+  const signingKey = `${oauthEncode(credentials.consumerSecret)}&${oauthEncode(credentials.accessTokenSecret)}`;
   const signature = createHmac("sha1", signingKey).update(signatureBase).digest("base64");
   const headerParameters = {
     ...oauthParameters,
@@ -88,8 +88,8 @@ async function main() {
     credentials: {
       accessToken: getInput("access-token"),
       accessTokenSecret: getInput("access-token-secret"),
-      apiKey: getInput("api-key"),
-      apiKeySecret: getInput("api-key-secret")
+      consumerKey: getInput("consumer-key"),
+      consumerSecret: getInput("consumer-secret")
     }
   });
 }

--- a/.github/actions/post-to-x/src/index.test.ts
+++ b/.github/actions/post-to-x/src/index.test.ts
@@ -4,8 +4,8 @@ import { getInput, publishTextToX, type XCredentials } from './index.ts';
 const credentials: XCredentials = {
   accessToken: 'access-token',
   accessTokenSecret: 'access-token-secret',
-  apiKey: 'api-key',
-  apiKeySecret: 'api-key-secret',
+  consumerKey: 'consumer-key',
+  consumerSecret: 'consumer-secret',
 };
 
 describe('publishTextToX', () => {

--- a/.github/actions/post-to-x/src/index.ts
+++ b/.github/actions/post-to-x/src/index.ts
@@ -5,8 +5,8 @@ type FetchFunction = typeof fetch;
 export type XCredentials = Readonly<{
   accessToken: string;
   accessTokenSecret: string;
-  apiKey: string;
-  apiKeySecret: string;
+  consumerKey: string;
+  consumerSecret: string;
 }>;
 
 class DeliveryResponseError extends Error {}
@@ -62,7 +62,7 @@ function createOAuthAuthorizationHeader(
   credentials: XCredentials,
 ): string {
   const oauthParameters = {
-    oauth_consumer_key: credentials.apiKey,
+    oauth_consumer_key: credentials.consumerKey,
     oauth_nonce: randomBytes(16).toString('hex'),
     oauth_signature_method: 'HMAC-SHA1',
     oauth_timestamp: String(Math.floor(Date.now() / 1000)),
@@ -88,7 +88,7 @@ function createOAuthAuthorizationHeader(
     oauthEncode(baseUrl),
     oauthEncode(parameterString),
   ].join('&');
-  const signingKey = `${oauthEncode(credentials.apiKeySecret)}&${oauthEncode(credentials.accessTokenSecret)}`;
+  const signingKey = `${oauthEncode(credentials.consumerSecret)}&${oauthEncode(credentials.accessTokenSecret)}`;
   const signature = createHmac('sha1', signingKey)
     .update(signatureBase)
     .digest('base64');
@@ -129,8 +129,8 @@ async function main(): Promise<void> {
     credentials: {
       accessToken: getInput('access-token'),
       accessTokenSecret: getInput('access-token-secret'),
-      apiKey: getInput('api-key'),
-      apiKeySecret: getInput('api-key-secret'),
+      consumerKey: getInput('consumer-key'),
+      consumerSecret: getInput('consumer-secret'),
     },
   });
 }

--- a/.github/workflows/notify-new-feed-items.yml
+++ b/.github/workflows/notify-new-feed-items.yml
@@ -106,8 +106,8 @@ jobs:
         with:
           access-token: ${{ secrets.X_ACCESS_TOKEN }}
           access-token-secret: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
-          api-key: ${{ secrets.X_API_KEY }}
-          api-key-secret: ${{ secrets.X_API_KEY_SECRET }}
+          consumer-key: ${{ secrets.X_CONSUMER_KEY }}
+          consumer-secret: ${{ secrets.X_CONSUMER_SECRET }}
           text: |
             ウェブログｺｼｰﾝしますた
 


### PR DESCRIPTION
## Summary
- Rename the X OAuth 1.0a credential inputs and internal fields to consumer key/secret terminology.
- Read `X_CONSUMER_KEY` and `X_CONSUMER_SECRET` from the notification workflow.
- Regenerate the committed Action bundle and update documentation/tests.

## Validation
- `pnpm --filter '@kamatte-syndrome/post-to-x' test`
- `pnpm --filter '@kamatte-syndrome/post-to-x' typecheck`
- `pnpm --filter '@kamatte-syndrome/post-to-x' build`
- `pnpm lint`