### PR TITLE
Remove portfolio thumbnail hover effect

### DIFF
--- a/apps/web/src/features/portfolio/components/PortfolioImage.test.tsx
+++ b/apps/web/src/features/portfolio/components/PortfolioImage.test.tsx
@@ -46,6 +46,7 @@ describe('PortfolioImage', () => {
     expect(link).toHaveAttribute('href', 'https://example.com');
     expect(link).toHaveAttribute('target', '_blank');
     expect(link).toHaveAttribute('rel', 'noreferrer');
+    expect(link).not.toHaveClass('hover:opacity-80');
   });
 
   it('renders the placeholder when the item has no image', () => {

--- a/apps/web/src/features/portfolio/components/PortfolioImage.tsx
+++ b/apps/web/src/features/portfolio/components/PortfolioImage.tsx
@@ -1,5 +1,4 @@
 import ContentImage from 'virtual:react-optimized-responsive-image/collection?src=@@/kamatte-syndrome-content/media&base=/media&widths=160;176;320;352';
-import { cn } from '@/utils/classNames';
 import type { PortfolioListItem } from '../types';
 import { PortfolioImagePlaceholder } from './PortfolioImagePlaceholder';
 
@@ -36,7 +35,7 @@ export function PortfolioImage({ item, link }: PortfolioImageProps) {
       href={link}
       target="_blank"
       rel="noreferrer"
-      className={cn(frameClassName, 'hover:opacity-80')}
+      className={frameClassName}
       aria-label={`${item.name} を開く`}
     >
       {imageContent}


### PR DESCRIPTION
## Summary

- remove the opacity change from linked Portfolio thumbnails on hover
- preserve the external-link behavior and accessibility attributes
- cover the absence of the hover class in the component test

## Why

Linked Portfolio thumbnail images became translucent on hover, which was an unwanted visual effect.

## Validation

- `pnpm --filter web test -- src/features/portfolio/components/PortfolioImage.test.tsx`
- `pnpm lint`