### PR TITLE
Fix psychedelic background recovery after GPU loss

### DIFF
--- a/apps/web/src/components/layouts/PsychedelicBackground.test.tsx
+++ b/apps/web/src/components/layouts/PsychedelicBackground.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { PsychedelicBackground } from './PsychedelicBackground';
 
@@ -40,6 +40,108 @@ describe('PsychedelicBackground', () => {
       );
     } finally {
       getContext.mockRestore();
+    }
+  });
+
+  it('reinitializes the WebGL renderer after its context is lost', async () => {
+    const originalMatchMedia = window.matchMedia;
+    const originalResizeObserver = globalThis.ResizeObserver;
+    const originalGetContext = HTMLCanvasElement.prototype.getContext;
+    const webglContext = {
+      ARRAY_BUFFER: 34962,
+      COLOR_BUFFER_BIT: 16384,
+      COMPILE_STATUS: 35713,
+      CULL_FACE: 2884,
+      DEPTH_TEST: 2929,
+      FLOAT: 5126,
+      FRAGMENT_SHADER: 35632,
+      LINK_STATUS: 35714,
+      SCISSOR_TEST: 3089,
+      STATIC_DRAW: 35044,
+      TRIANGLES: 4,
+      VERTEX_SHADER: 35633,
+      attachShader: vi.fn(),
+      bindBuffer: vi.fn(),
+      bufferData: vi.fn(),
+      clear: vi.fn(),
+      clearColor: vi.fn(),
+      compileShader: vi.fn(),
+      createBuffer: vi.fn(() => ({})),
+      createProgram: vi.fn(() => ({})),
+      createShader: vi.fn(() => ({})),
+      deleteBuffer: vi.fn(),
+      deleteProgram: vi.fn(),
+      deleteShader: vi.fn(),
+      disable: vi.fn(),
+      drawArrays: vi.fn(),
+      enable: vi.fn(),
+      enableVertexAttribArray: vi.fn(),
+      getAttribLocation: vi.fn(() => 0),
+      getProgramParameter: vi.fn(() => true),
+      getShaderParameter: vi.fn(() => true),
+      getUniformLocation: vi.fn(() => ({})),
+      linkProgram: vi.fn(),
+      scissor: vi.fn(),
+      shaderSource: vi.fn(),
+      uniform1f: vi.fn(),
+      uniform2f: vi.fn(),
+      useProgram: vi.fn(),
+      vertexAttribPointer: vi.fn(),
+      viewport: vi.fn(),
+    } as unknown as WebGLRenderingContext;
+    const getContext = vi.fn(() => webglContext);
+
+    class ResizeObserverMock {
+      disconnect() {}
+
+      observe() {}
+    }
+
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn(() => ({
+        addEventListener: vi.fn(),
+        matches: false,
+        removeEventListener: vi.fn(),
+      })),
+    });
+    Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+      configurable: true,
+      value: getContext,
+    });
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+
+    try {
+      const { container } = render(<PsychedelicBackground />);
+
+      await waitFor(() => {
+        expect(container.querySelector('canvas')).not.toBeNull();
+      });
+
+      const canvas = container.querySelector('canvas');
+
+      if (!canvas) {
+        throw new Error('Expected the WebGL renderer canvas to exist');
+      }
+
+      const contextLost = new Event('webglcontextlost', { cancelable: true });
+      canvas.dispatchEvent(contextLost);
+
+      await waitFor(() => {
+        expect(getContext).toHaveBeenCalledTimes(2);
+      });
+
+      expect(contextLost.defaultPrevented).toBe(true);
+    } finally {
+      Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+        configurable: true,
+        value: originalGetContext,
+      });
+      Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        value: originalMatchMedia,
+      });
+      vi.stubGlobal('ResizeObserver', originalResizeObserver);
     }
   });
 });

--- a/apps/web/src/components/layouts/PsychedelicBackground.tsx
+++ b/apps/web/src/components/layouts/PsychedelicBackground.tsx
@@ -20,6 +20,7 @@ const RENDERER_CANVAS_CLASS_NAME =
 
 type BackgroundRenderer = {
   dispose: () => void;
+  onDeviceLost: (callback: () => void) => () => void;
   render: (time: number) => void;
   resize: () => void;
 };
@@ -281,6 +282,19 @@ async function createWebgpuRenderer(
       uniformBuffer.destroy();
       canvas.remove();
     },
+    onDeviceLost: (callback) => {
+      let isActive = true;
+
+      void device.lost.then(() => {
+        if (isActive) {
+          callback();
+        }
+      });
+
+      return () => {
+        isActive = false;
+      };
+    },
     render,
     resize,
   } satisfies BackgroundRenderer;
@@ -397,6 +411,18 @@ function createWebglRenderer(
       gl.deleteProgram(program);
       canvas.remove();
     },
+    onDeviceLost: (callback) => {
+      const handleContextLost = (event: Event) => {
+        event.preventDefault();
+        callback();
+      };
+
+      canvas.addEventListener('webglcontextlost', handleContextLost);
+
+      return () => {
+        canvas.removeEventListener('webglcontextlost', handleContextLost);
+      };
+    },
     render,
     resize,
   } satisfies BackgroundRenderer;
@@ -415,9 +441,20 @@ export function PsychedelicBackground({
       return;
     }
 
+    const backgroundContainer = container;
     let cleanupRenderer: (() => void) | null = null;
     let frameId: number | null = null;
+    let isInitializing = false;
     let isDisposed = false;
+
+    const reinitialize = () => {
+      cleanupRenderer?.();
+      cleanupRenderer = null;
+
+      if (!isDisposed) {
+        void initialize();
+      }
+    };
 
     const stop = () => {
       if (frameId === null) {
@@ -428,10 +465,18 @@ export function PsychedelicBackground({
       frameId = null;
     };
 
-    const initialize = async () => {
+    async function initialize() {
+      if (isDisposed || isInitializing) {
+        return;
+      }
+
+      isInitializing = true;
       const renderer =
-        (await createWebgpuRenderer(container, clipRenderingToParent)) ??
-        createWebglRenderer(container, clipRenderingToParent);
+        (await createWebgpuRenderer(
+          backgroundContainer,
+          clipRenderingToParent,
+        )) ?? createWebglRenderer(backgroundContainer, clipRenderingToParent);
+      isInitializing = false;
 
       if (!renderer) {
         return;
@@ -512,10 +557,10 @@ export function PsychedelicBackground({
 
       const resizeObserver = new ResizeObserver(renderScene);
 
-      resizeObserver.observe(container);
+      resizeObserver.observe(backgroundContainer);
 
-      if (clipRenderingToParent && container.parentElement) {
-        resizeObserver.observe(container.parentElement);
+      if (clipRenderingToParent && backgroundContainer.parentElement) {
+        resizeObserver.observe(backgroundContainer.parentElement);
       }
 
       if (reducedMotionQuery.matches) {
@@ -527,6 +572,7 @@ export function PsychedelicBackground({
       window.addEventListener('resize', renderScene);
       document.addEventListener('visibilitychange', handleVisibilityChange);
       reducedMotionQuery.addEventListener('change', handleMotionChange);
+      const removeDeviceLostListener = renderer.onDeviceLost(reinitialize);
 
       cleanupRenderer = () => {
         stop();
@@ -537,14 +583,29 @@ export function PsychedelicBackground({
           handleVisibilityChange,
         );
         reducedMotionQuery.removeEventListener('change', handleMotionChange);
+        removeDeviceLostListener();
         renderer.dispose();
       };
+    }
+
+    const handleRecoveryVisibilityChange = () => {
+      if (!document.hidden && cleanupRenderer === null) {
+        void initialize();
+      }
     };
 
+    document.addEventListener(
+      'visibilitychange',
+      handleRecoveryVisibilityChange,
+    );
     void initialize();
 
     return () => {
       isDisposed = true;
+      document.removeEventListener(
+        'visibilitychange',
+        handleRecoveryVisibilityChange,
+      );
       cleanupRenderer?.();
     };
   }, [clipRenderingToParent]);


### PR DESCRIPTION
## Summary
- recreate the background renderer after WebGL context loss or WebGPU device loss
- retry renderer initialization on foregrounding when recovery is pending
- add a WebGL context-loss regression test

## Validation
- pnpm --filter web test -- PsychedelicBackground.test.tsx
- pnpm lint
- pnpm typecheck
- pnpm build
- git diff --check