### PR TITLE
Sort biography history chronologically

### DIFF
--- a/apps/web/src/features/biography/components/HistoryList.test.tsx
+++ b/apps/web/src/features/biography/components/HistoryList.test.tsx
@@ -3,19 +3,21 @@ import { describe, expect, it } from 'vitest';
 import { HistoryList } from './HistoryList';
 
 describe('HistoryList', () => {
-  it('renders each history year and description', () => {
+  it('renders each history entry in ascending year order', () => {
     render(
       <HistoryList
         history={[
-          { year: 2018, description: 'Opened the site' },
           { year: 2026, description: 'Refined the biography page' },
+          { year: 2018, description: 'Opened the site' },
         ]}
       />,
     );
 
-    expect(screen.getByText('2018年')).toBeInTheDocument();
-    expect(screen.getByText('Opened the site')).toBeInTheDocument();
-    expect(screen.getByText('2026年')).toBeInTheDocument();
-    expect(screen.getByText('Refined the biography page')).toBeInTheDocument();
+    expect(
+      screen.getAllByRole('term').map(({ textContent }) => textContent),
+    ).toEqual(['2018年', '2026年']);
+    expect(
+      screen.getAllByRole('definition').map(({ textContent }) => textContent),
+    ).toEqual(['Opened the site', 'Refined the biography page']);
   });
 });

--- a/apps/web/src/features/biography/components/HistoryList.tsx
+++ b/apps/web/src/features/biography/components/HistoryList.tsx
@@ -5,9 +5,11 @@ type HistoryListProps = {
 };
 
 export function HistoryList({ history }: HistoryListProps) {
+  const chronologicalHistory = [...history].sort((a, b) => a.year - b.year);
+
   return (
     <dl className="mx-auto grid w-fit max-w-full gap-0.5 text-left text-sm leading-6 sm:text-base md:mx-0 md:max-w-md">
-      {history.map((item) => (
+      {chronologicalHistory.map((item) => (
         <div
           key={`${item.year}-${item.description}`}
           className="grid grid-cols-[3.5rem_minmax(0,1fr)] gap-1 sm:gap-4"


### PR DESCRIPTION
## Summary
- Display biography history in ascending year order
- Cover the order with a regression test

## Tests
- `pnpm typecheck`
- `pnpm --filter web test -- HistoryList`
- `pnpm lint`
- `git diff --check`