### PR TITLE
fix(actions): grant permission to remove PR labels

### DIFF
--- a/.github/workflows/update-action-bundles.yml
+++ b/.github/workflows/update-action-bundles.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: read
-  issues: write
+  pull-requests: write
 
 concurrency:
   group: update-action-bundles-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
- grant the GITHUB_TOKEN pull-request write access for removing the trigger label
- retain least-privilege contents read access

## Testing
- git diff --check
- YAML syntax check