### PR TITLE
chore(actions): automate action bundle updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,6 @@ permissions:
 
 jobs:
   ci:
-    permissions:
-      contents: read
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.1
@@ -66,51 +63,6 @@ jobs:
             printf '%s\n' "$changes"
             exit 1
           fi
-      - name: Suggest updating GitHub Action bundles
-        if: >-
-          failure() &&
-          steps.verify-action-bundles.outcome == 'failure' &&
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/github-script@v9.0.0
-        with:
-          script: |
-            const marker = '<!-- update-action-bundles -->';
-            const body = [
-              marker,
-              'GitHub Actionのバンドルに未コミットの差分があります。',
-              '',
-              '`update-action-bundles` ラベルを付けると、GitHub App botが`.github/actions/*/dist`を再生成してコミットします。',
-            ].join('\n');
-            const comments = await github.paginate(
-              github.rest.issues.listComments,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-              },
-            );
-            const existingComment = comments.find(
-              (comment) =>
-                comment.user.login === 'github-actions[bot]' &&
-                comment.body.includes(marker),
-            );
-
-            if (existingComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existingComment.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
       - run: pnpm test
       - run: pnpm typecheck
       - run: pnpm lint:ci

--- a/.github/workflows/update-action-bundles.yml
+++ b/.github/workflows/update-action-bundles.yml
@@ -2,22 +2,25 @@ name: Update GitHub Action bundles
 
 on:
   pull_request:
-    types:
-      - labeled
+    paths:
+      - '.github/actions/**'
+      - 'packages/github-actions-artifacts/**'
+      - 'packages/tsconfig/**'
+      - package.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+      - .node-version
 
 permissions:
   contents: read
-  pull-requests: write
 
 concurrency:
   group: update-action-bundles-${{ github.event.pull_request.number }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   update:
-    if: >-
-      github.event.label.name == 'update-action-bundles' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.1
@@ -65,9 +68,3 @@ jobs:
           git -c core.hooksPath=/dev/null push \
             "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
             "HEAD:${PR_HEAD_REF}"
-
-      - name: Remove trigger label
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: gh pr edit "$PR_NUMBER" --remove-label update-action-bundles


### PR DESCRIPTION
GitHub Actionのソース・依存関係変更時に、バンドル済みdistをGitHub App botで自動更新します。CIから手動ラベル運用の案内を削除します。