### PR TITLE
chore(actions): use ref-based concurrency group

### DIFF
--- a/.github/workflows/update-action-bundles.yml
+++ b/.github/workflows/update-action-bundles.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: update-action-bundles-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Action成果物更新Workflowのconcurrency groupを、Workflow名とgithub.refで構成します。PRごとの並行実行制御は維持します。