### PR TITLE
chore(vscode): exclude action bundles from editor tooling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,15 @@
 {
   "files.watcherExclude": {
-    "**/routeTree.gen.ts": true
+    "**/routeTree.gen.ts": true,
+    "**/.github/actions/*/dist/**": true
   },
   "search.exclude": {
-    "**/routeTree.gen.ts": true
+    "**/routeTree.gen.ts": true,
+    "**/.github/actions/*/dist/**": true
   },
   "files.readonlyInclude": {
-    "**/routeTree.gen.ts": true
+    "**/routeTree.gen.ts": true,
+    "**/.github/actions/*/dist/**": true
   },
   "[javascript]": {
     "editor.defaultFormatter": "biomejs.biome"


### PR DESCRIPTION
## Summary
- exclude local GitHub Action dist files from VS Code file watching and search
- mark generated Action bundles as read-only in the editor

## Verification
- jq empty .vscode/settings.json
- git diff --check