### PR TITLE
chore(ci): migrate to pnpm/setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,12 @@ jobs:
       - uses: actions/checkout@v7.0.1
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@v6.0.10
       - uses: actions/setup-node@v7.0.0
         with:
           node-version-file: .node-version
-          cache: pnpm
+      - uses: pnpm/setup@v2.1.0
+        with:
+          cache: true
       - id: content-token
         uses: actions/create-github-app-token@v3.2.0
         with:
@@ -44,7 +45,6 @@ jobs:
           token: ${{ steps.content-token.outputs.token }}
           fetch-depth: 1
           persist-credentials: false
-      - run: pnpm install
       - name: Restore Turborepo cache
         uses: actions/cache@v6.1.0
         with:
@@ -91,22 +91,18 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
-
-      - uses: pnpm/action-setup@v6.0.10
       - uses: actions/setup-node@v7.0.0
         with:
           node-version-file: .node-version
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+      - uses: pnpm/setup@v2.1.0
+        with:
+          cache: true
       - run: pnpm --filter './.github/actions/*' build
-
       - id: app-token
         uses: actions/create-github-app-token@v3.2.0
         with:
           client-id: ${{ vars.KAMATTE_SYNDROME_BOT_APP_CLIENT_ID }}
           private-key: ${{ secrets.KAMATTE_SYNDROME_BOT_APP_PRIVATE_KEY }}
-
       - name: Commit regenerated bundles
         env:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Replace pnpm/action-setup with pnpm/setup@v2.1.0 in both CI jobs. Keep Node.js sourced from .node-version, then let pnpm/setup restore the pnpm store cache and install dependencies automatically.

Remove the separate pnpm install steps and the explicit --frozen-lockfile option, since CI enables frozen installs by default when a lockfile exists. The checks job now installs dependencies before checking out content; content is still available before the build.

Validation: pnpm lint, workflow YAML parsing, and git diff --check passed. Full GitHub Actions execution has not yet been verified.
